### PR TITLE
Feat: Suppress result dialog for single renames

### DIFF
--- a/Plugins/MaterialInstanceRenamer/Source/MaterialInstanceRenamer/Private/MaterialInstanceRenamer.cpp
+++ b/Plugins/MaterialInstanceRenamer/Source/MaterialInstanceRenamer/Private/MaterialInstanceRenamer.cpp
@@ -125,15 +125,18 @@ namespace MenuExtension_MaterialInstance
             }
         }
 
-        FText DialogTitle = FLocalizationManager::GetText("RenameComplete");
-        FText DialogMessage = FText::Format(
-            FLocalizationManager::GetText("RenameSummary"),
-            FText::AsNumber(RenamedCount),
-            FText::AsNumber(SkippedCount),
-            FText::AsNumber(FailedCount),
-            FText::AsNumber(InvalidPatternCount)
-        );
-        FMessageDialog::Open(EAppMsgType::Ok, DialogMessage, &DialogTitle);
+        if (MaterialInstances.Num() > 1)
+        {
+            FText DialogTitle = FLocalizationManager::GetText("RenameComplete");
+            FText DialogMessage = FText::Format(
+                FLocalizationManager::GetText("RenameSummary"),
+                FText::AsNumber(RenamedCount),
+                FText::AsNumber(SkippedCount),
+                FText::AsNumber(FailedCount),
+                FText::AsNumber(InvalidPatternCount)
+            );
+            FMessageDialog::Open(EAppMsgType::Ok, DialogMessage, &DialogTitle);
+        }
     }
 }
 


### PR DESCRIPTION
The result summary dialog is now suppressed when renaming a single material instance via the context menu.

This improves the user experience for single renames by avoiding an unnecessary confirmation dialog, as the result is already logged to the Output Log. The summary dialog will still be displayed when renaming multiple assets at once.