### PR TITLE
Feat: Add support for Unreal Engine 5.6

### DIFF
--- a/Plugins/MaterialInstanceRenamer/MaterialInstanceRenamer.uplugin
+++ b/Plugins/MaterialInstanceRenamer/MaterialInstanceRenamer.uplugin
@@ -17,7 +17,8 @@
 	"Installed": false,
 	"EngineVersion": [
 		"5.4.0",
-		"5.5.0"
+		"5.5.0",
+		"5.6.0"
 	],
 	"Modules": [
 		{


### PR DESCRIPTION
Adds "5.6.0" to the list of supported engine versions in the MaterialInstanceRenamer.uplugin file.