### PR TITLE
ci: grant write permissions to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The semantic-release job requires write permissions to push tags and update the changelog. This change adds the 'contents: write' permission to the release workflow to fix the EGITNOPERMISSION error.