### PR TITLE
Update build settings to use Latest version

### DIFF
--- a/Source/MIRenamer.Target.cs
+++ b/Source/MIRenamer.Target.cs
@@ -8,7 +8,7 @@ public class MIRenamerTarget : TargetRules
 	public MIRenamerTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
 		ExtraModuleNames.AddRange( new string[] { "MIRenamer" } );
 	}

--- a/Source/MIRenamerEditor.Target.cs
+++ b/Source/MIRenamerEditor.Target.cs
@@ -8,7 +8,7 @@ public class MIRenamerEditorTarget : TargetRules
 	public MIRenamerEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
 		ExtraModuleNames.AddRange( new string[] { "MIRenamer" } );
 	}


### PR DESCRIPTION
## Summary
Updated the default build settings configuration to use the latest version instead of a pinned V5 version across both game and editor target files.

## Changes
- Updated `MIRenamerTarget.cs`: Changed `DefaultBuildSettings` from `BuildSettingsVersion.V5` to `BuildSettingsVersion.Latest`
- Updated `MIRenamerEditorTarget.cs`: Changed `DefaultBuildSettings` from `BuildSettingsVersion.V5` to `BuildSettingsVersion.Latest`

## Details
This change allows the project to automatically use the latest available build settings version rather than being locked to V5. This ensures the project can benefit from newer build configurations and improvements as they become available in the engine.

https://claude.ai/code/session_015aaDy1mwbyoRcVqJeGkRXi